### PR TITLE
Removed --ignore-scripts flag from npm install to resolve errors w/ libxml-xsd

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ function downloadPackages(commandName, cacheDir, cb) {
     exec('bower install', execOpts, cb);
     break;
   case 'npm':
-    exec('npm install --ignore-scripts', execOpts, cb);
+    exec('npm install', execOpts, cb);
     break;
   default:
     cb(new Error('Command mismatch'));


### PR DESCRIPTION
Libxml-xsd package needs install script to run to build correctly, removed --ignore-scripts flag
