### PR TITLE
Modified pkgr to use rsync, conditionally preserve target directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,16 +101,16 @@ function createDirectoryCopy(src, target, cb) {
     //_.partial(lockfile.lock, copylock, lockOpts),
     cb => {
       if (argv['preserve-target']) {
-        console.log(`npm-pkgr removing ${target}`);
+        debug(`npm-pkgr removing ${target}`);
         fs.remove(target, cb);
       } else {
-        console.log(`npm-pkgr preserving ${target}`);
+        debug(`npm-pkgr preserving ${target}`);
         cb();
       }
     },
     function(cb) {
       if (!argv['symlink']) {
-        console.log('npm-pkgr trying `rsync -at --delete` to copy');
+        debug('npm-pkgr trying `rsync -at --delete` to copy');
         const rsync = new Rsync()
           .flags('at')
           .delete()
@@ -118,18 +118,18 @@ function createDirectoryCopy(src, target, cb) {
           .destination(target);
         rsync.execute(function(err) {
             if (err) {
-              console.log('npm-pkgr falling back to cp -rp to copy');
+              debug('npm-pkgr falling back to cp -rp to copy');
               fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
             } else {
-              console.log('npm-pkgr used `rsync -at --delete` to copy');
+              debug('npm-pkgr used `rsync -at --delete` to copy');
               cb();
             }
           },
           function(stdoutBuff) {
-            console.log(`[rsync stdout] ${stdoutBuff.toString()}`);
+            debug(`[rsync stdout] ${stdoutBuff.toString()}`);
           },
           function(stderrBuff) {
-            console.log(`[rsync stderr] ${stderrBuff.toString()}`);
+            debug(`[rsync stderr] ${stderrBuff.toString()}`);
           }
         );
       } else {

--- a/index.js
+++ b/index.js
@@ -109,13 +109,13 @@ function createDirectoryCopy(src, target, cb) {
     function(cb) {
       if (!argv['symlink']) {
         const superTarget = _.dropRight(target.split('/')).join('/');
-        try {
-          new Rsync().flags('rt').source(src).destination(superTarget).execute(cb);
-          console.log('npm-pkgr used rsync -rt to copy');
-        } catch (err) {
-          console.log('npm-pkgr used cp -rp to copy');
-          fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
-        }
+        console.log('npm-pkgr trying rsync -rt to copy');
+        new Rsync().flags('rt').source(src).destination(superTarget).execute(function(err) {
+          if (err) {
+            console.log('npm-pkgr falling back to cp -rp to copy');
+            fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
+          } else { console.log('npm-pkgr used rsync -rt to copy'); }
+        });
       } else {
         fs.symlink(src, target, 'dir', cb);
       }

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function createDirectoryCopy(src, target, cb) {
           console.log('npm-pkgr used rsync -rt to copy');
         } catch (err) {
           console.log('npm-pkgr used cp -rp to copy');
-          fs.copy(src, target, { preserveTimestamps: true }, cb);
+          fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
         }
       } else {
         fs.symlink(src, target, 'dir', cb);

--- a/index.js
+++ b/index.js
@@ -109,13 +109,18 @@ function createDirectoryCopy(src, target, cb) {
     function(cb) {
       if (!argv['symlink']) {
         const superTarget = _.dropRight(target.split('/')).join('/');
-        console.log('npm-pkgr trying rsync -rt to copy');
-        new Rsync().flags('rt').source(src).destination(superTarget).execute(function(err) {
-          if (err) {
-            console.log('npm-pkgr falling back to cp -rp to copy');
-            fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
-          } else { console.log('npm-pkgr used rsync -rt to copy'); }
-        });
+        console.log('npm-pkgr trying `rsync -rt --delete` to copy');
+        new Rsync()
+          .flags('rt')
+          .set('delete')
+          .source(src)
+          .destination(superTarget)
+          .execute(function(err) {
+            if (err) {
+              console.log('npm-pkgr falling back to cp -rp to copy');
+              fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
+            } else { console.log('npm-pkgr used `rsync -rt --delete` to copy'); }
+          });
       } else {
         fs.symlink(src, target, 'dir', cb);
       }

--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ function installPackages(opts, cb) {
 }
 
 function npmPkgr(opts, cb) {
-  console.log('starting npm-pkgr with opts: %j', opts);
+  console.log('starting npm-pkgr with opts: %s', JSON.stringify(opts, null, 2));
 
   var commandName = argv._[0];
   var cacheRoot = argv['cache-directory'];

--- a/index.js
+++ b/index.js
@@ -108,13 +108,12 @@ function createDirectoryCopy(src, target, cb) {
     },
     function(cb) {
       if (!argv['symlink']) {
-        const superTarget = _.dropRight(target.split('/')).join('/');
         console.log('npm-pkgr trying `rsync -at --delete` to copy');
         const rsync = new Rsync()
           .flags('at')
           .delete()
-          .source(src)
-          .destination(superTarget);
+          .source(src + '/*')
+          .destination(target);
         rsync.execute(function(err) {
             if (err) {
               console.log('npm-pkgr falling back to cp -rp to copy');

--- a/index.js
+++ b/index.js
@@ -119,7 +119,10 @@ function createDirectoryCopy(src, target, cb) {
             if (err) {
               console.log('npm-pkgr falling back to cp -rp to copy');
               fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
-            } else { console.log('npm-pkgr used `rsync -rt --delete` to copy'); }
+            } else {
+              console.log('npm-pkgr used `rsync -rt --delete` to copy');
+              cb();
+            }
           });
       } else {
         fs.symlink(src, target, 'dir', cb);

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function createDirectoryCopy(src, target, cb) {
         const rsync = new Rsync()
           .flags('at')
           .delete()
-          .source(src + '/*')
+          .source(src + '/.')
           .destination(target);
         rsync.execute(function(err) {
             if (err) {

--- a/index.js
+++ b/index.js
@@ -109,21 +109,28 @@ function createDirectoryCopy(src, target, cb) {
     function(cb) {
       if (!argv['symlink']) {
         const superTarget = _.dropRight(target.split('/')).join('/');
-        console.log('npm-pkgr trying `rsync -rt --delete` to copy');
-        new Rsync()
-          .flags('rt')
-          .set('delete')
+        console.log('npm-pkgr trying `rsync -at --delete` to copy');
+        const rsync = new Rsync()
+          .flags('at')
+          .delete()
           .source(src)
-          .destination(superTarget)
-          .execute(function(err) {
+          .destination(superTarget);
+        rsync.execute(function(err) {
             if (err) {
               console.log('npm-pkgr falling back to cp -rp to copy');
               fs.copy(src, target, { clobber: true, preserveTimestamps: true }, cb);
             } else {
-              console.log('npm-pkgr used `rsync -rt --delete` to copy');
+              console.log('npm-pkgr used `rsync -at --delete` to copy');
               cb();
             }
-          });
+          },
+          function(stdoutBuff) {
+            console.log(`[rsync stdout] ${stdoutBuff.toString()}`);
+          },
+          function(stderrBuff) {
+            console.log(`[rsync stderr] ${stderrBuff.toString()}`);
+          }
+        );
       } else {
         fs.symlink(src, target, 'dir', cb);
       }

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function createDirectoryCopy(src, target, cb) {
     // and reads shouldn't conflict.
     //_.partial(lockfile.lock, copylock, lockOpts),
     cb => {
-      if (!argv['preserve-target']) {
+      if (argv['preserve-target']) {
         console.log(`npm-pkgr removing ${target}`);
         fs.remove(target, cb);
       } else {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash": "^3.10.1",
     "minimist": "^1.1.0",
     "npm-version": "^1.1.0",
+    "rsync": "^0.5.0",
     "yargs": "^3.32.0"
   },
   "devDependencies": {


### PR DESCRIPTION
npm-pkgr first tries to copy with rsync, falling back to naive cp upon failure

`--preserve-target` will rsync cache to target directory without first removing target, similar to npm install behavior
- If I ever bother merging into main, remember that rsync is only useful for devs to update dependencies, and doesn't actually help on jenkins etc. w/ brand new clones. Thus, recommend `--preserve-target` correspond to `NODE_ENV=dev`
