### PR TITLE
Fix getting into corrupted state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build/Release
 
 # Dependency directory
 node_modules
+
+# misc
+*.swp

--- a/index.js
+++ b/index.js
@@ -297,6 +297,8 @@ function installPackages(opts, cb) {
           async.series({
             acquireLock: _.partial(lockfile.lock, cachelock, lockOpts),
             srcExists: function(cb) {
+              // occassionally get into state where we only have doneFilePath
+              // but not src, so check for both (ys, DSP-11156)
               fs.exists(src, function(exists) {
                 cb(null, exists);
               });

--- a/index.js
+++ b/index.js
@@ -313,7 +313,7 @@ function installPackages(opts, cb) {
           process.once('SIGINT', cancelAndExit);
 
           if (res.doneFileExists) {
-            if (res.srcExists) {
+            if (!res.srcExists) {
               console.log(`Error: ${src} not found but reporting finished, reinstalling...`);
               fs.removeSync(doneFilePath);
             } else {

--- a/index.js
+++ b/index.js
@@ -317,7 +317,6 @@ function installPackages(opts, cb) {
           if (res.doneFileExists) {
             if (!res.srcExists) {
               console.log(`Error: ${src} not found but reporting finished, reinstalling...`);
-              fs.removeSync(doneFilePath);
             } else {
               return cb(null, false);
             }


### PR DESCRIPTION
Occasionally get into corrupted state where `/mnt/npm-caches/<ver>/<sha1>` contains only the `finished` file, then `ENOENT`-ing when trying to copy from `node_modules`

This makes an extra check whether `node_modules` exists before skipping install step. If it doesn't, throw an error and re-enter install logic.

TODO: Debug why this state is reached...
